### PR TITLE
Choose curl interface

### DIFF
--- a/src/Academe/SagePay/Model/TransactionAbstract.php
+++ b/src/Academe/SagePay/Model/TransactionAbstract.php
@@ -296,17 +296,17 @@ abstract class TransactionAbstract
 
     /**
      * Make a new VendorTxCode.
-     * To be give the code some context, we start it with a timestamp then add
-     * on a number based on milliseconds.
-     * The VendorTxCode is limited to 40 characters.
-     * This is 17 + 13 = 30 characters.
+     * To be give the code some context, we start it with a timestamp before
+     * we add on a random hex string.
+     * The VendorTxCode is limited to 40 characters, so we use 12 bytes for the hex.
      * Override this method if you want a different format.
      */
 
     public function makeVendorTxCode()
     {
-        $VendorTxCode = uniqid(date('Ymd-His-'), false);
-        return $VendorTxCode;
+        $data = openssl_random_pseudo_bytes(12);
+
+        return vsprintf('%s-%s', Array(date('Ymd-His'), bin2hex($data)));
     }
 
     /**
@@ -327,4 +327,3 @@ abstract class TransactionAbstract
         );
     }
 }
-

--- a/src/Academe/SagePay/ServiceAbstract.php
+++ b/src/Academe/SagePay/ServiceAbstract.php
@@ -211,6 +211,13 @@ class ServiceAbstract //extends Model\XmlAbstract
     protected $delivery_address = null;
 
     /**
+     * Due to Sagepay's IP restrictions, it may be necessary for some people
+     * to set the interface curl communicates over if a server has more than one IP.
+     */
+     
+    protected $interface = null;
+
+    /**
      * Inject the transaction model.
      */
 
@@ -663,6 +670,15 @@ class ServiceAbstract //extends Model\XmlAbstract
         }
     }
 
+
+    /**
+     * Set the interface CURL is to use
+     */
+    public function setInterface($interface)
+    {
+        return $this->interface = $interface;
+    }
+
     /**
      * Send a POST message to SagePay and collect the result.
      * TODO: move to Transport namespace and a separate injected class.
@@ -694,12 +710,16 @@ class ServiceAbstract //extends Model\XmlAbstract
         curl_setopt($curlSession, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curlSession, CURLOPT_SSL_VERIFYHOST, 2);
 
+        if (!empty($this->interface)) {
+            curl_setopt($curlSession, CURLOPT_INTERFACE, $this->interface);
+        }
+
         // Send the request and store the result in an array.
         $rawresponse = trim(curl_exec($curlSession));
         $curl_info = curl_getinfo($curlSession);
 
         // Split response into name=value pairs
-        // The documentation states "CRLF" divides the lines. We will use the regex match \R to 
+        // The documentation states "CRLF" divides the lines. We will use the regex match \R to
         // catch any platform-specific version of line endings that the future may throw at us.
         $response = preg_split('/$\R?^/m', $rawresponse);
 
@@ -743,4 +763,3 @@ class ServiceAbstract //extends Model\XmlAbstract
         return $this->tx_model->isPaymentSuccess();
     }
 }
-


### PR DESCRIPTION
Due to Sagepay's IP restrictions, it may be necessary for some people to set the interface curl communicates over if their www server has more than one IP. This update allows that.